### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/YeDawa/DumpSync/security/code-scanning/2](https://github.com/YeDawa/DumpSync/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/rust.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing behavior for checkout/build/test and does not grant unnecessary write scopes. The `publish` job authenticates to crates.io with `CARGO_REGISTRY_TOKEN`, so no additional `GITHUB_TOKEN` write permission is required based on the shown steps.

Change location:
- In `.github/workflows/rust.yml`, insert `permissions:` between the `on:` block and `env:` block (or any top-level location), with `contents: read`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
